### PR TITLE
Update curriculum-file-structure.md

### DIFF
--- a/docs/i18n/italian/curriculum-file-structure.md
+++ b/docs/i18n/italian/curriculum-file-structure.md
@@ -69,7 +69,7 @@ Inoltre, probabilmente vorrai rinominare il certificato e il blocco `{superBlock
 1. Aggiorna il file `index.md` nella cartella qui sopra, cambiando i valori `title` e `superBlock` al nuovo nome.
 1. Per ogni cartella di un blocco all'interno della precedente, aggiorna `index.md` affinché usi il valore corretto di `superBlock`.
 1. Nel file `client/src/resources/cert-and-project-map.ts`, aggiorna il percorso per il certificato in cima al file, e il valore di `title` per quel superblocco. **Nota** che cambiare `title` qui **romperà** l'abilità di vedere la certificazione per questo superblocco. Fa affidamento sul titolo del superblocco per abbinare il titolo del certificato. Vorrai probabilmente rinominare la certificazione allo stesso tempo.
-1. Update the `superBlockCertTypeMap` key in `shared/config/certification-settings.js` to the new superBlock name.
+1. Aggiorna la chiave `superBlockCertTypeMap` key in `shared/config/certification-settings.js`  con il nuovo nome del superblocco.
 1. Aggiorna il valore del percorso in `client/src/assets/icons/index.tsx`.
 1. Per ogni lingua in `client/i18n/locales`, aggiorna il file `intro.json` file affinché usi il nuovo `dashedName` del superblocco. Nel file inglese aggiorna anche `title`.
 1. Check the `shared/config/i18n/all-langs.js` file to see if the superBlock is enabled in i18n builds. Aggiorna il valore dove è usato.


### PR DESCRIPTION
In the section "Rinominare un superblocco", step 8 reads "Update the superBlockCertTypeMap key in shared/config/certification-settings.js to the new superBlock name." This appears to be an oversight as the rest of the document is in Italian. The correct translation would be: "Aggiorna la chiave superBlockCertTypeMap in shared/config/certification-settings.js con il nuovo nome del superblocco."

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
